### PR TITLE
fix: 2번, 8번에서도 3번으로 넘어갈 수 있게 수정

### DIFF
--- a/src/main/java/com/dispatch/dump/configModule/aop/AOPConfig.java
+++ b/src/main/java/com/dispatch/dump/configModule/aop/AOPConfig.java
@@ -52,7 +52,7 @@ public class AOPConfig {
 
                     }
                 } else {
-                    if (!(className.equals("Step2Controller") || className.equals("Step7Controller") || className.equals("Step8Controller"))) {
+                    if (!(className.equals("Step2Controller") || className.equals("Step3Controller") || className.equals("Step7Controller") || className.equals("Step8Controller"))) {
                         result = "redirect:/";
                     } else {
                         result = pjp.proceed();


### PR DESCRIPTION
제출처 계정에서도 3번페이지로 넘어갈 수 있어야 해서 수정했습니다. 2번 페이지에서는 제출받은 일보를 클릭했을 때 3번으로 넘어가야하고, 8번 페이지에서는 검색된 전표 중 상태가 "제출"이면서 작성자가 기사일 땐 3번페이지로 넘어가야 합니다! 혹시 문제가 된다면 알아서 바꿔주세요,,,